### PR TITLE
[AWS][IAM] Restrict KMS Policies to Specified Account

### DIFF
--- a/deployments/terraform_modules/santa_api/modules/firehose/kms.tf
+++ b/deployments/terraform_modules/santa_api/modules/firehose/kms.tf
@@ -25,19 +25,6 @@ resource "aws_kms_key" "rudolph_eventsupload_kms_key" {
 
 data "aws_iam_policy_document" "rudolph_eventsupload_kms_key_policy" {
   statement {
-    sid    = "Enable IAM User Permissions"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.aws_account_id}:root"]
-    }
-
-    actions   = ["kms:*"]
-    resources = ["*"]
-  }
-
-  statement {
     sid    = "Allow principals in the account to use the key"
     effect = "Allow"
 
@@ -51,12 +38,6 @@ data "aws_iam_policy_document" "rudolph_eventsupload_kms_key_policy" {
       variable = "kms:CallerAccount"
       values   = [var.aws_account_id]
     }
-
-    # condition {
-    #   test     = "StringLike"
-    #   variable = "kms:ViaService"
-    #   values   = ["firehose.*.amazonaws.com"]
-    # }
 
     actions = [
       "kms:CreateGrant",

--- a/deployments/terraform_modules/santa_api/modules/store/dynamodb.tf
+++ b/deployments/terraform_modules/santa_api/modules/store/dynamodb.tf
@@ -53,8 +53,4 @@ resource "aws_dynamodb_table" "store" {
   point_in_time_recovery {
     enabled = true
   }
-
-  # tags = {
-  #   Name = "Rudolph"
-  # }
 }


### PR DESCRIPTION
to: @Ryxias 
cc: @airbnb/rudolph-maintainers

## Background

KMS key policies should be limited to only the principals within the same account and these changes optimize and cleanup the KMS policy for clarity.

## Changes

* Scope KMS principals to just the specified account
* Cleanup duplicate permissions

## Testing

This has been deployed internally and validated against working systems.
