### PR TITLE
Adjust Terraform Syntax in _backend.tf

### DIFF
--- a/deployments/environments/example/_backend.tf
+++ b/deployments/environments/example/_backend.tf
@@ -20,6 +20,8 @@ terraform {
 provider "aws" {
   region = "us-east-1"
   default_tags {
-    Name = "Rudolph"
+    tags = {
+      Name = "Rudolph"
+    }
   }
 }

--- a/deployments/terraform_modules/santa_api/modules/store/kms.tf
+++ b/deployments/terraform_modules/santa_api/modules/store/kms.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "store_sse_permissions" {
     condition {
       test = "StringEquals"
       variable = "kms:CallerAccount"
-      values = ["${var.aws_account_id}"]
+      values = [var.aws_account_id]
     }
 
     actions = [


### PR DESCRIPTION
cc: @airbnb/rudolph-maintainers

## Changes
Firstly, thanks for making this repo available as open source, it's great.

The setup instructions were very clear and I was able to setup our environment in a few minutes.
However, I had to change the `_backend.tf` as terraform (v0.14.11) was not happy with the syntax, so I thought I would open this PR to let you know. The other small change was just to get rid of the warning about the deprecated interpolation syntax.



