### PR TITLE
[TF] Update AWS and required TF versions, support `al2` images for Lambdas, and `arm64` Lambda support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 PKG = github.com/airbnb/rudolph
 VERSION := $(shell git describe --tags --always)
 DOCS_DIR ?= ./docs
-DEPLOYMENT_ZIP_PATH = $(PWD)/build/package/deployment.zip
+RUDOLPH_API_DEPLOYMENT_ZIP_PATH = $(PWD)/build/package/api_deployment.zip
+RUDOLPH_API_AUTHORIZER_DEPLOYMENT_ZIP_PATH = $(PWD)/build/package/api_authorizer_deployment.zip
 TERRAFORM_DEPLOYMENTS_DIR = $(PWD)/deployments/environments
-TF_DEFAULT_FLAGS = --var zip_file_path="$(DEPLOYMENT_ZIP_PATH)" --var package_version=$(VERSION)
+TF_DEFAULT_FLAGS = --var lambda_api_zip="$(RUDOLPH_API_DEPLOYMENT_ZIP_PATH)" --var lambda_authorizer_zip="$(RUDOLPH_API_AUTHORIZER_DEPLOYMENT_ZIP_PATH)"
 LDFLAGS=-ldflags="-X main.version=$(VERSION)"
 
 # Check to ensure the prefix is being passed in as an arg like `ENV=<YOUR_ENVIRONMENT>`

--- a/deployments/environments/example/README.md
+++ b/deployments/environments/example/README.md
@@ -58,7 +58,9 @@ terraform {
 provider "aws" {
   region = "us-east-1"
   default_tags {
+   tags = {
     Name = "Rudolph"
+   }
   }
 }
 ```

--- a/deployments/environments/example/versions.tf
+++ b/deployments/environments/example/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = ">= 1.3.6"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38.0"
+      version = "~> 3.76.1"
     }
   }
 }

--- a/deployments/terraform_modules/default_main.tf
+++ b/deployments/terraform_modules/default_main.tf
@@ -18,9 +18,9 @@ module "santa_api" {
   route53_zone_name   = var.route53_zone_name
   use_existing_route53_zone = var.use_existing_route53_zone
 
-  lambda_zip      = var.zip_file_path
-  package_version = var.package_version
-
+  lambda_api_zip  = var.lambda_api_zip
+  lambda_authorizer_zip = var.lambda_authorizer_zip
+  
   enable_s3_logging = var.enable_s3_logging
 
   kms_key_administrators_arns = var.kms_key_administrators_arns

--- a/deployments/terraform_modules/default_variables.tf
+++ b/deployments/terraform_modules/default_variables.tf
@@ -1,11 +1,11 @@
-variable "zip_file_path" {
+variable "lambda_api_zip" {
   type        = string
-  description = "Path to zip on disk to use for deployment of Lambda functions. This gets passed in from 'make deploy' command"
+  description = "Full path to zip with go binary for Lambda to be uploaded to S3"
 }
 
-variable "package_version" {
+variable "lambda_authorizer_zip" {
   type        = string
-  description = "Version of golang binary being used. This value comes from git tags and is used when the Lambda package is uploaded to S3. This gets passed in from 'make deploy' command"
+  description = "Full path to zip with go binary for Lambda to be uploaded to S3"
 }
 
 // These variables are provided by config.auto.tfvars.json

--- a/deployments/terraform_modules/santa_api/_variables.tf
+++ b/deployments/terraform_modules/santa_api/_variables.tf
@@ -39,14 +39,14 @@ variable "stage_name" {
   description = "Name of stage to use for this deployment"
 }
 
-variable "lambda_zip" {
+variable "lambda_api_zip" {
   type        = string
   description = "Full path to zip with go binary for Lambda to be uploaded to S3"
 }
 
-variable "package_version" {
+variable "lambda_authorizer_zip" {
   type        = string
-  description = "Version of golang binary being used. This value comes from git tags and is used when the Lambda package is uploaded to S3"
+  description = "Full path to zip with go binary for Lambda to be uploaded to S3"
 }
 
 variable "use_existing_route53_zone" {

--- a/deployments/terraform_modules/santa_api/authorizer.tf
+++ b/deployments/terraform_modules/santa_api/authorizer.tf
@@ -9,9 +9,9 @@ module "rudolph_api_authorizer" {
   alias_name                = var.stage_name
   api_gateway_id            = aws_api_gateway_rest_api.api_gateway.id
   api_gateway_execution_arn = aws_api_gateway_rest_api.api_gateway.execution_arn
-  lambda_source_bucket      = aws_s3_bucket_object.santa_api_source.bucket
-  lambda_source_key         = aws_s3_bucket_object.santa_api_source.key
-  lambda_source_hash        = local.lambda_source_hash
+  lambda_source_bucket      = aws_s3_bucket_object.santa_api_authorizer_source.bucket
+  lambda_source_key         = aws_s3_bucket_object.santa_api_authorizer_source.key
+  lambda_source_hash        = local.lambda_authorizer_hash
 
   env_vars = {
     REGION      = var.region

--- a/deployments/terraform_modules/santa_api/main.tf
+++ b/deployments/terraform_modules/santa_api/main.tf
@@ -14,10 +14,6 @@ resource "aws_api_gateway_rest_api" "api_gateway" {
 
   # Use the authorizer's UsageIdentifierKey to uniquely identify an endpoint.
   api_key_source = "AUTHORIZER"
-
-  # tags = {
-  #   Name = "Rudolph"
-  # }
 }
 
 ##########################

--- a/deployments/terraform_modules/santa_api/modules/firehose/iam.tf
+++ b/deployments/terraform_modules/santa_api/modules/firehose/iam.tf
@@ -175,8 +175,4 @@ resource "aws_iam_role" "eventsupload_firehose_role" {
   name   = "${var.prefix}_rudolph_eventsupload_firehose_role"
   path   = "/rudolph/"
   assume_role_policy = data.aws_iam_policy_document.firehose_assume_role_policy.json
-
-  tags = {
-    Name = "Rudolph"
-  }
 }

--- a/deployments/terraform_modules/santa_api/modules/firehose/kinesis_firehose.tf
+++ b/deployments/terraform_modules/santa_api/modules/firehose/kinesis_firehose.tf
@@ -4,10 +4,6 @@ locals {
 
 resource "aws_cloudwatch_log_group" "eventsupload_firehose" {
   name              = "/aws/kinesisfirehose/${local.firehose_name}"
-
-  tags = {
-    Name = "Rudolph"
-  }
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "eventsupload_firehose" {

--- a/deployments/terraform_modules/santa_api/modules/firehose/kms.tf
+++ b/deployments/terraform_modules/santa_api/modules/firehose/kms.tf
@@ -17,10 +17,6 @@ resource "aws_kms_key" "rudolph_eventsupload_kms_key" {
   enable_key_rotation = true
   description         = "Rudolph EventsUpload S3 Server-Side Encryption"
   policy              = data.aws_iam_policy_document.rudolph_eventsupload_kms_key_policy.json
-
-  tags = {
-    Name = "Rudolph"
-  }
 }
 
 data "aws_iam_policy_document" "rudolph_eventsupload_kms_key_policy" {

--- a/deployments/terraform_modules/santa_api/modules/firehose/s3.tf
+++ b/deployments/terraform_modules/santa_api/modules/firehose/s3.tf
@@ -70,8 +70,4 @@ resource "aws_s3_bucket" "rudolph_eventsupload_firehose" {
       }
     }
   }
-
-  tags = {
-    Name = "Rudolph"
-  }
 }

--- a/deployments/terraform_modules/santa_api/modules/lambda/api-handler/_variables.tf
+++ b/deployments/terraform_modules/santa_api/modules/lambda/api-handler/_variables.tf
@@ -31,7 +31,7 @@ variable "endpoint" {
 variable "lambda_handler" {
   type        = string
   description = "Lambda function handler path. If left blank, this will default to a formatted handler based on the endpoint variable value"
-  default     = ""
+  default     = "bootstrap"
 }
 
 variable "alias_name" {

--- a/deployments/terraform_modules/santa_api/modules/lambda/api-handler/iam.tf
+++ b/deployments/terraform_modules/santa_api/modules/lambda/api-handler/iam.tf
@@ -7,10 +7,6 @@ resource "aws_iam_role" "api_handler_role" {
   name               = "${var.prefix}_rudolph_${var.endpoint}_role"
   assume_role_policy = data.aws_iam_policy_document.lambda_execution_policy.json
   path               = "/rudolph/"
-
-  # tags = {
-  #   Name = "Rudolph"
-  # }
 }
 
 data "aws_iam_policy_document" "lambda_execution_policy" {

--- a/deployments/terraform_modules/santa_api/modules/lambda/api-handler/lambda.tf
+++ b/deployments/terraform_modules/santa_api/modules/lambda/api-handler/lambda.tf
@@ -3,7 +3,8 @@
 #
 
 locals {
-  handler = var.lambda_handler == "" ? var.endpoint : var.lambda_handler
+  handler = "bootstrap"
+  runtime = "provided.al2"
 }
 
 
@@ -11,8 +12,9 @@ resource "aws_lambda_function" "api_handler" {
   function_name = "${var.prefix}_rudolph_${var.endpoint}"
   role          = aws_iam_role.api_handler_role.arn
   handler       = local.handler
-  runtime       = "go1.x"
+  runtime       = local.runtime
   publish       = true
+  architectures = ["arm64"]
 
   s3_bucket        = var.lambda_source_bucket
   s3_key           = var.lambda_source_key
@@ -34,10 +36,6 @@ resource "aws_lambda_function" "api_handler" {
       variables = var.env_vars
     }
   }
-
-  # tags = {
-  #   Name = "Rudolph"
-  # }
 }
 
 resource "aws_lambda_alias" "api_handler" {

--- a/deployments/terraform_modules/santa_api/modules/lambda/authorizer/iam.tf
+++ b/deployments/terraform_modules/santa_api/modules/lambda/authorizer/iam.tf
@@ -8,10 +8,6 @@ resource "aws_iam_role" "invocation_role" {
   name               = "${var.prefix}_rudolph_api_gateway_authorizer"
   path               = "/rudolph/"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
-
-  # tags = {
-  #   Name = "Rudolph"
-  # }
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {

--- a/deployments/terraform_modules/santa_api/modules/lambda/lambda-source/s3.tf
+++ b/deployments/terraform_modules/santa_api/modules/lambda/lambda-source/s3.tf
@@ -39,20 +39,12 @@ resource "aws_s3_bucket" "santa_api_source" {
       }
     }
   }
-
-  # tags = {
-  #   Name = "Rudolph"
-  # }
 }
 
 // KMS Key for S3 server-side encryption
 resource "aws_kms_key" "santa_api_source" {
   enable_key_rotation = true
   description         = "Rudolph Source S3 Server-Side Encryption"
-
-  # tags = {
-  #   Name = "Rudolph"
-  # }
 }
 
 // KMS Alias for S3 server-side encryption

--- a/deployments/terraform_modules/santa_api/route53.tf
+++ b/deployments/terraform_modules/santa_api/route53.tf
@@ -4,10 +4,6 @@
 resource "aws_acm_certificate" "api_ssl_certificate" {
   domain_name       = local.api_domain_name
   validation_method = "DNS"
-
-  # tags = {
-  #   Name = "Rudolph"
-  # }
 }
 
 resource "aws_acm_certificate_validation" "api_certificate_validation" {

--- a/deployments/terraform_modules/santa_api/usage_plan.tf
+++ b/deployments/terraform_modules/santa_api/usage_plan.tf
@@ -18,11 +18,6 @@
 #     rate_limit  = 1
 #   }
 
-#   tags = {
-#     Name = "Rudolph"
-#   }
-# }
-
 # resource "aws_api_gateway_usage_plan_key" "main" {
 #   key_id        = aws_api_gateway_api_key.mykey.id
 #   key_type      = "API_KEY"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,11 +9,14 @@ DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 # Establish directories
 BUILD_DIR=$DIR/build
 LINUX_BUILD_DIR=$BUILD_DIR/linux
+LINUX_BUILD_DIR_API=$LINUX_BUILD_DIR/api
+LINUX_BUILD_DIR_AUTHORIZER=$LINUX_BUILD_DIR/authorizer
 MACOS_BUILD_DIR=$BUILD_DIR/macos
 APPS_DIR=$DIR/cmd
 CLI_NAME=rudolph
 PKG_DIR=$BUILD_DIR/package
-DEPLOYMENT_ZIP_PATH=$PKG_DIR/deployment.zip
+API_DEPLOYMENT_ZIP_PATH=$PKG_DIR/api_deployment.zip
+API_AUTHORIZER_DEPLOYMENT_ZIP_PATH=$PKG_DIR/api_authorizer_deployment.zip
 
 cd "$DIR"
 
@@ -23,27 +26,33 @@ rm -rf $BUILD_DIR
 # Do the build things
 echo "*** compiling application binaries... ***"
 
-echo "  compiling api..."
-GOOS=linux GOARCH=amd64 go build -o $LINUX_BUILD_DIR/api $APPS_DIR/api
+echo "  compiling api in linux:arm64..."
+GOOS=linux GOARCH=arm64 go build -o $LINUX_BUILD_DIR_API/bootstrap $APPS_DIR/api
 
-echo "  compiling authorizer..."
-GOOS=linux GOARCH=amd64 go build -o $LINUX_BUILD_DIR/authorizer $APPS_DIR/authorizer
+echo "  compiling authorizer in linux:arm64..."
+GOOS=linux GOARCH=arm64 go build -o $LINUX_BUILD_DIR_AUTHORIZER/bootstrap $APPS_DIR/authorizer
 
-echo "  compiling cli..."
-GOOS=darwin GOARCH=amd64 go build -o $MACOS_BUILD_DIR/cli_amd64 $APPS_DIR/cli
-GOOS=darwin GOARCH=arm64 go build -o $MACOS_BUILD_DIR/cli_arm64 $APPS_DIR/cli
-lipo -create -output $MACOS_BUILD_DIR/cli $MACOS_BUILD_DIR/cli_amd64 $MACOS_BUILD_DIR/cli_arm64
-ln -sf $MACOS_BUILD_DIR/cli $DIR/$CLI_NAME
+if [ "$(uname)" == "Darwin" ]; then
+    echo "  compiling cli..."
+    GOOS=darwin GOARCH=amd64 go build -o $MACOS_BUILD_DIR/cli_amd64 $APPS_DIR/cli
+    GOOS=darwin GOARCH=arm64 go build -o $MACOS_BUILD_DIR/cli_arm64 $APPS_DIR/cli
+    lipo -create -output $MACOS_BUILD_DIR/cli $MACOS_BUILD_DIR/cli_amd64 $MACOS_BUILD_DIR/cli_arm64
+    ln -sf $MACOS_BUILD_DIR/cli $DIR/$CLI_NAME
+fi
 
 echo "*** packaging... ***"
 
 mkdir $PKG_DIR
 # remember zip 2nd arg zips up all the specified directories. We omit the dir info by cd,
 # but you could use the -j option as well.
-cd $LINUX_BUILD_DIR; zip -r $DEPLOYMENT_ZIP_PATH *
+cd $LINUX_BUILD_DIR_API; zip -r $API_DEPLOYMENT_ZIP_PATH *
+cd $LINUX_BUILD_DIR_AUTHORIZER; zip -r $API_AUTHORIZER_DEPLOYMENT_ZIP_PATH *
 
 echo "*** complete ***"
 
 echo "  created:"
-echo "    $DEPLOYMENT_ZIP_PATH"
-echo "    $DIR/$CLI_NAME"
+echo "    $API_DEPLOYMENT_ZIP_PATH"
+echo "    $API_AUTHORIZER_DEPLOYMENT_ZIP_PATH"
+if [ "$(uname)" == "Darwin" ]; then
+    echo "    $MACOS_BUILD_DIR/cli"
+fi


### PR DESCRIPTION
to: @airbnb/rudolph-maintainers

## Background

This PR seeks to adopt the changes as AWS is seeking to deprecate al1 backed Lambdas by end of year 2023...ref: https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/.

## Changes

* Update TF lambda providers to support AL2 images via the `provided.al2` lambda images for running custom binaries like compiled golang binaries
* Update build scripts and makefiles to support the necessary changes to ship the binaries as required per AWS
* Update our TF required versions to something more modern and to the latest supported AWS provider for long-term support
* In the process, let's save some money and migrate to ARM64 instances...testing in the lab environment has shown a decrease in runtime costs by about 9%
  * Its not the 20% or up to 34% as advertised but 9% is 9% of money back in our pockets
  * Ref : https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/

## Testing

Deployed to personal development AWS account:

<img width="1569" alt="Screenshot 2023-09-05 at 08 22 32" src="https://github.com/airbnb/rudolph/assets/39590744/9339d999-a680-4dc8-ac75-056b73805087">

