### PR TITLE
Fix Santa sync protocol for versions of Santa >= 2024.6

### DIFF
--- a/internal/handlers/ruledownload/clean_sync.go
+++ b/internal/handlers/ruledownload/clean_sync.go
@@ -1,6 +1,7 @@
 package ruledownload
 
 import (
+	"encoding/json"
 	"log"
 	"net/http"
 
@@ -46,11 +47,18 @@ func (d concreteGlobalRuleDownloader) handle(machineID string, cursor ruledownlo
 		rules[i] = rule.SantaRule
 	}
 
+	// Marshal the cursor to a string
+	jsonCursor, err := json.Marshal(nextCursor)
+	if err != nil {
+		log.Printf("  json.Marshal Error %s", err.Error())
+		return response.APIResponse(http.StatusInternalServerError, err)
+	}
+
 	return response.APIResponse(
 		http.StatusOK,
 		RuledownloadResponse{
 			Rules:  DDBRulesToResponseRules(rules),
-			Cursor: &nextCursor,
+			Cursor: string(jsonCursor),
 		},
 	)
 }

--- a/internal/handlers/ruledownload/feed_sync.go
+++ b/internal/handlers/ruledownload/feed_sync.go
@@ -1,6 +1,7 @@
 package ruledownload
 
 import (
+	"encoding/json"
 	"log"
 	"net/http"
 
@@ -70,11 +71,18 @@ func (d concreteFeedRuleDownloader) handle(machineID string, cursor ruledownload
 		rules[i] = rule.SantaRule
 	}
 
+	// Marshal the cursor to a string
+	jsonCursor, err := json.Marshal(nextCursor)
+	if err != nil {
+		log.Printf("  json.Marshal Error %s", err.Error())
+		return response.APIResponse(http.StatusInternalServerError, err)
+	}
+
 	return response.APIResponse(
 		http.StatusOK,
 		RuledownloadResponse{
 			Rules:  DDBRulesToResponseRules(rules),
-			Cursor: &nextCursor,
+			Cursor: string(jsonCursor),
 		},
 	)
 }

--- a/internal/handlers/ruledownload/handler.go
+++ b/internal/handlers/ruledownload/handler.go
@@ -13,12 +13,13 @@ import (
 )
 
 // RuleDownloadHandler handles requests to the /ruledownload and /ruledownload/{machine_id} API endpoints
-//   During every sync, Santa sensors make successive POST requests to the /ruledownload endpoint to paginate
-//   through all rules.
-//   When given a blank postbody (e.g. {}), it indicates the very first request in a sequence. If the
-//   API returns a "cursor" in the response body, this cursor will be sent back verbatim in a subsequent postbody.
-//   When a response does not return a "cursor" in the body, it signals that there are no more items to page
-//   through, and the sensor will stop sending requests.
+//
+//	During every sync, Santa sensors make successive POST requests to the /ruledownload endpoint to paginate
+//	through all rules.
+//	When given a blank postbody (e.g. {}), it indicates the very first request in a sequence. If the
+//	API returns a "cursor" in the response body, this cursor will be sent back verbatim in a subsequent postbody.
+//	When a response does not return a "cursor" in the body, it signals that there are no more items to page
+//	through, and the sensor will stop sending requests.
 type PostRuledownloadHandler struct {
 	booted        bool
 	cursorService ruledownloadCursorService
@@ -27,7 +28,6 @@ type PostRuledownloadHandler struct {
 	mhandler      machineRuleDownloder
 }
 
-//
 func (h *PostRuledownloadHandler) Boot() (err error) {
 	if h.booted {
 		return
@@ -59,12 +59,10 @@ func (h *PostRuledownloadHandler) Boot() (err error) {
 	return
 }
 
-//
 func (h *PostRuledownloadHandler) Handles(request events.APIGatewayProxyRequest) bool {
 	return request.Resource == "/ruledownload/{machine_id}" && request.HTTPMethod == "POST"
 }
 
-//
 func (h *PostRuledownloadHandler) Handle(request events.APIGatewayProxyRequest) (*events.APIGatewayProxyResponse, error) {
 	machineID, ok := request.PathParameters["machine_id"]
 	if !ok {
@@ -79,6 +77,15 @@ func (h *PostRuledownloadHandler) Handle(request events.APIGatewayProxyRequest) 
 	if err != nil {
 		log.Printf("  Failed to unmarshall ruledownload request Error %s", err.Error())
 		return response.APIResponse(http.StatusBadRequest, response.ErrInvalidBodyResponse)
+	}
+
+	if ruledownloadRequest.RawCursor != "" {
+		ruledownloadRequest.Cursor = &ruledownloadCursor{}
+		err = json.Unmarshal([]byte(ruledownloadRequest.RawCursor), ruledownloadRequest.Cursor)
+		if err != nil {
+			log.Printf("  Failed to unmarshall cursor Error %s", err.Error())
+			return response.APIResponse(http.StatusBadRequest, response.ErrInvalidBodyResponse)
+		}
 	}
 
 	return h.handleRuleDownload(machineID, ruledownloadRequest)

--- a/internal/handlers/ruledownload/handler_test.go
+++ b/internal/handlers/ruledownload/handler_test.go
@@ -8,9 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//
 // Test Mocks
-//
 type mockCursorService func(req RuledownloadRequest, machineID string) (cursor ruledownloadCursor, err error)
 
 func (m mockCursorService) ConstructCursor(req RuledownloadRequest, machineID string) (cursor ruledownloadCursor, err error) {
@@ -35,17 +33,13 @@ func (m mockMachineRuleDownloader) handle(machineID string, ruledownloadRequest 
 	return m(machineID, ruledownloadRequest)
 }
 
-//
 // Coerce our mocks to conform to the interfaces that they are intended to implement
-//
 var _ ruledownloadCursorService = mockCursorService(nil)
 var _ globalRuleDownloader = mockGlobalRuleDownloader(nil)
 var _ feedRuleDownloader = mockFeedRuleDownloader(nil)
 var _ machineRuleDownloder = mockMachineRuleDownloader(nil)
 
-//
 // Actual Tests
-//
 func Test_PostRuledownloadHandler_SendToCorrectHandler(t *testing.T) {
 	type test struct {
 		cursor         ruledownloadCursor
@@ -180,7 +174,7 @@ func Test_PostRuledownloadHandler_CursorServiceReceivesCorrectRequest(t *testing
 		PathParameters: map[string]string{
 			"machine_id": machineID,
 		},
-		Body: `{"cursor":{"strategy":2,"batch_size":7,"page":2,"pk":"AAAA","sk":"eeeeee"}}`,
+		Body: `{"cursor": "{\"strategy\":2, \"batch_size\":7,\"page\":2,\"pk\":\"AAAA\",\"sk\":\"eeeeee\"}"}`,
 	}
 
 	_, err := handler.Handle(request)

--- a/internal/handlers/ruledownload/request.go
+++ b/internal/handlers/ruledownload/request.go
@@ -4,5 +4,6 @@ package ruledownload
 type RuledownloadRequest struct {
 	// Cursor is, verbatim, the Cursor that is returned to a sensor in a previous RuledownloadResponse
 	// On the very first rule download request in a flight sequence, there will be no cursor provided.
-	Cursor *ruledownloadCursor `json:"cursor,omitempty"`
+	RawCursor string              `json:"cursor,omitempty"`
+	Cursor    *ruledownloadCursor `json:"-"`
 }

--- a/internal/handlers/ruledownload/response.go
+++ b/internal/handlers/ruledownload/response.go
@@ -10,7 +10,7 @@ type RuledownloadResponse struct {
 	Rules []RuledownloadRule `json:"rules"`
 	// When a cursor is returned by the server, it is an indicator to the Santa sensor that there are
 	// additional rules to be paginated through. This cursor is passed to the next request.
-	Cursor *ruledownloadCursor `json:"cursor,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
 }
 
 // RuledownloadRule is a single rule returned in a RuledownloadResponse


### PR DESCRIPTION
to: @natesinger @mike-flowers-airbnb
cc: @airbnb/rudolph-maintainers

## Background

In the Santa [2024.6](https://github.com/google/santa/releases/tag/2024.6) release the parsing of the JSON in the sync protocol was handed to the protobuf library which uses the [Protobuf to JSON mapping](https://protobuf.dev/programming-guides/proto3/#json). This had the side effect of making Santa more strict about the protocol fields than it was before.

The `cursor` field in the RuleDownload request is expected to be [an opaque field of that's a string](https://northpole.dev/development/sync-protocol.html#ruledownload-request). However [Rudolph is currently serializing the cursor object into the field directly in the request](https://github.com/airbnb/rudolph/blob/f5ec87900eb60459747f7eb5f1dadc8d577c80fb/internal/handlers/ruledownload/request.go#L7) and [the response](https://github.com/airbnb/rudolph/blob/f5ec87900eb60459747f7eb5f1dadc8d577c80fb/internal/handlers/ruledownload/response.go#L13). This mismatch causes Rudolph to be incompatible with Santa for versions >= 2024.6.

## Changes

* This fixes #52 
* This PR changes how the `Cursor` field is handled by the RuleDownload `Request` and `Response` structs 
* First the request is parsed directly and then the cursor field is parsed again into the `Cursor` struct
* For responses, the `Cursor` struct is first serialized to a json string then added to the `Response` struct.

## Testing

* Unit tests have been updated
* Testing was performed by users who'd applied the patch to their versions of rudolph. See this chat in the [#santa](https://macadmins.slack.com/archives/C0E1VRBGW/p1728484639759519?thread_ts=1726702763.180099&cid=C0E1VRBGW) channel on the mac admins slack.

### Manual Testing Steps

* Download and install Santa version 2024.9
* Apply the patch to rudolph and setup an instance of Rudolph
* Configure santa to use your Rudolph instance as a sync service set `SyncBaseURL`
* Run `santactl sync` from the terminal
